### PR TITLE
Escape the checklist name for JS validation

### DIFF
--- a/classes/ValidFormBuilder/Group.php
+++ b/classes/ValidFormBuilder/Group.php
@@ -173,7 +173,7 @@ class Group extends Element
                     $name = $this->__name;
                     break;
                 case ValidForm::VFORM_CHECK_LIST:
-                    $name = (strpos($this->__name, "[]") === false) ? $this->__name . "[]" : $this->__name;
+                    $name = (strpos($this->__name, "[]") === FALSE) ? $this->__name . '\\\\[\\\\]' : $this->__name;
                     break;
             }
         }


### PR DESCRIPTION
This fixes the long standing issue 57 on Google Code: https://code.google.com/p/validformbuilder/issues/detail?id=57

---

What steps will reproduce the problem?
1. Add a VFORM_CHECKLIST field and add checkboxes to it.
2. The resulting JS validation will break jQuery fatally. It outputs `objForm.addElement('field_name[]',...`, which jQuery sees as a broken attribute.
3. This prevents the JS validation from working and causes the form to be submitted prematurely.

The line causing this issue is https://code.google.com/p/validformbuilder/source/browse/trunk/libraries/ValidForm/class.vf_group.php#154

What is the expected output? What do you see instead?

It should be escaped for the JavaScript output like so: `$name = (strpos($this->__name, "[]") === FALSE) ? $this->__name . '\\\\[\\\\]' : $this->__name;`

As per http://mathiasbynens.be/notes/css-escapes#javascript

This will prevent the error.
