### PR TITLE
feat: automatically mark and close stale issues

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,26 @@
+name: 'Stale issue handler'
+on:
+  workflow_dispatch:
+  schedule:
+    # This runs every day 20 minutes before midnight: https://crontab.guru/#40_23_*_*_*
+    - cron: '40 23 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'validformbuilder'
+    steps:
+      - uses: actions/stale@v9
+        id: issue-stale
+        name: 'Mark stale issues, close stale issues'
+        with:
+          ascending: true
+          days-before-issue-close: 7
+          days-before-issue-stale: 365 # issues with no activity in over a year
+          days-before-pr-close: -1
+          days-before-pr-stale: -1
+          remove-issue-stale-when-updated: true
+          stale-issue-label: 'stale'
+          stale-issue-message: 'This issue has been automatically marked as stale due to two years of inactivity. It will be closed in 7 days unless there’s further input. If you believe this issue is still relevant, please leave a comment or provide updated details. Thank you.'
+          close-issue-message: 'This issue has been automatically closed due to two years of inactivity. If you’re still experiencing a similar problem or have additional details to share, please open a new issue following our current issue template. Your updated report helps us investigate and address concerns more efficiently. Thank you for your understanding!'
+          operations-per-run: 300 # 1 operation per 100 issues, the rest is to label/comment/close


### PR DESCRIPTION
This workflow helps keeping the repository issues manager clean. 

- When an issue has been stale for 1 year, a comment is placed informing the participants that this issue will be closed in 7 days.
- After no activity (new comments) for 7 days, the issue will be automatically closed, assuming it's no longer active.